### PR TITLE
Changed gitbook's book.json config to remove default sharing plugin

### DIFF
--- a/markdown/book.json
+++ b/markdown/book.json
@@ -2,5 +2,6 @@
   "gitbook": ">=2.0.0",
   "title": "Standard Music Font Layout",
   "description": "Specification for SMuFL",
-  "language": "en"
+  "language": "en",
+  "plugins": ["-sharing"]
 }


### PR DESCRIPTION
This doesn't include the regenerated HTML files in `gitbook/`, but I'm happy to include those if needed.