### PR TITLE
cutOut anchors defined from origin in SMuFL v1.3, so no special case needed anymore

### DIFF
--- a/scripts/fontlab/generate_font_metadata.py
+++ b/scripts/fontlab/generate_font_metadata.py
@@ -97,14 +97,8 @@ for g in fl.font.glyphs:
     if len(g.anchors) > 0:
         font_metadata['glyphsWithAnchors'][g.note] = {}
         for anchor in g.anchors:
-
-            if anchor.name.startswith('cutOut'):
-                fontlab_metadata['glyphsWithAnchors'][g.note][anchor.name] = \
-                    [to_cartesian(anchor.x - bounding_box.ll.x),
-                     to_cartesian(anchor.y - bounding_box.ll.y)]
-            else:
-                fontlab_metadata['glyphsWithAnchors'][g.note][anchor.name] = \
-                    [to_cartesian(anchor.x), to_cartesian(anchor.y)]
+            fontlab_metadata['glyphsWithAnchors'][g.note][anchor.name] = \
+                [to_cartesian(anchor.x), to_cartesian(anchor.y)]
 
     if int(g.unicode) >= 0xF400:
         font_metadata["optionalGlyphs"][g.note] = {'classes': []}


### PR DESCRIPTION
Since the cutOut anchor positions are now defined from the glyph origin (0,0) and not the bounding box, special casing calculation of the cartesian coordinates in staff spaces is no longer needed. The same fix should be applied to @bentimms’ scripts/glyphsapp/ in the Steinberg smufl repository (and perhaps have the scripts moved over here).

I did not test this change, as I do all my work in Glyphs with my own tools.