### PR TITLE
fix names of precomposed repeat glyphs

### DIFF
--- a/markdown/implementation_notes/repeats.md
+++ b/markdown/implementation_notes/repeats.md
@@ -1,6 +1,6 @@
 Scoring programs should draw their own repeat barlines using primitives
 to draw the thick and thin lines and **repeatDots** to draw the dots, not
-use the precomposed glyphs **leftRepeat** or **rightRepeat**.
+use the precomposed glyphs **repeatLeft** or **repeatRight**.
 
 **dalSegno** and **daCapo** are provided for compatibility with the Unicode
 Musical Symbols range. Scoring applications should allow the user to


### PR DESCRIPTION
The implementation notes refer to `leftRepeat` and `rightRepeat`, which are not the names of the elements