### PR TITLE
Chord diagrams glyphs registration

### DIFF
--- a/markdown/tables/chord-diagrams.md
+++ b/markdown/tables/chord-diagrams.md
@@ -14,3 +14,5 @@ Implementation notes
 ---------------------
 
 Scoring applications may choose to draw chord diagram fretboards using primitives in order to provide the end user with control over grid spacing and line thickness relative to size.
+
+**fretboardFilledCircle**, **fretboardX** and **fretboardO** should be centered around the origin, so they will have negative left side-bearings and extend below the baseline. This makes them easier to position on fretboard diagrams, as the glyph can then be positioned precisely at the intersection of the perpendicular lines describing the fret and the string.


### PR DESCRIPTION
Added specification for registration of filled/unfilled circle and X glyphs used to indicate fingerings in guitar chord diagrams, such that they should be centered vertically and horizontally around the origin, for ease of positioning. This fixes #117.