### PR TITLE
Fix contrast accessibility issues

### DIFF
--- a/mdbook/theme/css/general.css
+++ b/mdbook/theme/css/general.css
@@ -103,6 +103,16 @@ h6:target::before {
     text-decoration: none;
 }
 
+
+/* This will need to be updated if more dark modes are added. */
+.content img .ayu {
+    background: var(--inline-code-color);
+}
+
+.content img .coal {
+    background: var(--inline-code-color);
+}
+
 table {
     margin: 0 auto;
     border-collapse: collapse;

--- a/mdbook/theme/css/variables.css
+++ b/mdbook/theme/css/variables.css
@@ -57,15 +57,15 @@
     --sidebar-bg: #292c2f;
     --sidebar-fg: #a1adb8;
     --sidebar-non-existant: #505254;
-    --sidebar-active: #3473ad;
+    --sidebar-active: #87bcfc;
     --sidebar-spacer: #393939;
 
     --scrollbar: var(--sidebar-fg);
 
-    --icons: #43484d;
+    --icons: #5d656c;
     --icons-hover: #b3c0cc;
 
-    --links: #2b79a2;
+    --links: #63a8d3;
 
     --inline-code-color: #c5c8c6;
 
@@ -137,7 +137,7 @@
     --sidebar-bg: #282d3f;
     --sidebar-fg: #c8c9db;
     --sidebar-non-existant: #505274;
-    --sidebar-active: #2b79a2;
+    --sidebar-active: #63a8d3;
     --sidebar-spacer: #2d334f;
 
     --scrollbar: var(--sidebar-fg);
@@ -145,7 +145,7 @@
     --icons: #737480;
     --icons-hover: #b7b9cc;
 
-    --links: #2b79a2;
+    --links: #63a8d3;
 
     --inline-code-color: #c5c8c6;
 
@@ -185,7 +185,7 @@
     --icons: #737480;
     --icons-hover: #262625;
 
-    --links: #2b79a2;
+    --links: #63a8d3;
 
     --inline-code-color: #6e6b5e;
 
@@ -218,15 +218,15 @@
         --sidebar-bg: #292c2f;
         --sidebar-fg: #a1adb8;
         --sidebar-non-existant: #505254;
-        --sidebar-active: #3473ad;
+        --sidebar-active: #87bcfc;
         --sidebar-spacer: #393939;
 
         --scrollbar: var(--sidebar-fg);
 
-        --icons: #43484d;
+        --icons: #5d656c;
         --icons-hover: #b3c0cc;
 
-        --links: #2b79a2;
+        --links: #63a8d3;
 
         --inline-code-color: #c5c8c6;
 


### PR DESCRIPTION
This pull request modifies the colours of the text to meet AAA accessibility guidelines. It also adds a background colour to images in .ayu and .coal themes, though this may have unintended side effects, as the selector is vague.

It has not been tested as a build, and the effects should be viewed by someone that can build the mdBook before merging.

It does not address the other accessibility issues mentioned in #192.