### PR TITLE
Fix dead Simplified Music Notation link

### DIFF
--- a/mdbook/src/implementation_notes/simplified_music_notation.md
+++ b/mdbook/src/implementation_notes/simplified_music_notation.md
@@ -5,4 +5,4 @@ white notes on the piano (e.g. B sharp and E sharp) are notated using
 “history signs.”
 
 For more information about Simplified Music Notation, visit
-<http://www.simplifiedmusicnotation.org/>
+<https://web.archive.org/web/20230120000705/https://simplifiedmusicnotation.org/>


### PR DESCRIPTION
Fixes w3c-cg/smufl#338.

Replaces the parked `simplifiedmusicnotation.org` URL with a stable Internet Archive snapshot across the mdbook source + published HTML artifacts so docs stop sending readers to a parked domain.

No behavioral change; link-only update.