### PR TITLE
Add CI validation for metadata and automate spec publishing

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,108 @@
+name: Validate and publish specification
+
+on:
+  push:
+    branches: [gh-pages]
+  pull_request:
+    branches: [gh-pages]
+  workflow_dispatch:
+
+env:
+  MDBOOK_VERSION: "0.5.4"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate metadata and build the book
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install metadata validator
+        run: pip install check-jsonschema
+
+      - name: Validate glyphnames.json against schema
+        run: check-jsonschema --schemafile metadata/schema/glyphnames.schema.json metadata/glyphnames.json
+
+      - name: Validate ranges.json against schema
+        run: check-jsonschema --schemafile metadata/schema/ranges.schema.json metadata/ranges.json
+
+      - name: Validate classes.json against schema
+        run: check-jsonschema --schemafile metadata/schema/classes.schema.json metadata/classes.json
+
+      - name: Check cross-file metadata consistency
+        run: python3 metadata/schema/check_consistency.py
+
+      - name: Install mdBook
+        run: |
+          mkdir -p "$HOME/mdbook-bin"
+          curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz -C "$HOME/mdbook-bin"
+          echo "$HOME/mdbook-bin" >> "$GITHUB_PATH"
+
+      - name: Build the book
+        working-directory: mdbook
+        run: mdbook build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/gh-pages'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install mdBook
+        run: |
+          mkdir -p "$HOME/mdbook-bin"
+          curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz -C "$HOME/mdbook-bin"
+          echo "$HOME/mdbook-bin" >> "$GITHUB_PATH"
+
+      - name: Build the book
+        working-directory: mdbook
+        run: mdbook build
+
+      - name: Assemble site
+        run: |
+          rm -rf _site
+          mkdir _site
+          cp -r mdbook/book _site/latest
+          cp -r drafts _site/drafts
+          cp -r releases _site/releases
+          cp -r gitbook _site/gitbook
+          cp -r metadata _site/metadata
+          cp index.html _site/index.html
+          cp w3c.json _site/w3c.json
+
+      - name: Set up Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -30,9 +30,14 @@ This document describes the build process for the SMuFL specification.
 
 **w3c.json** contains configuration data used by the W3C organisation to manage their many GitHub repositories.
 
+**metadata/schema** contains [JSON Schema](https://json-schema.org/) definitions for **glyphnames.json**, **classes.json** and **ranges.json**, plus **check_consistency.py**, a script that checks relationships between those three files that a schema alone can't express (e.g. that every glyph's codepoint falls within the range it belongs to).
+
+**.github/workflows/pages.yml** is the GitHub Actions workflow that validates and publishes the specification (see below).
+
 ## Prerequisites
 
 * [Install mdBook](https://rust-lang.github.io/mdBook/guide/installation.html)
+* Python 3, if you want to run the metadata validation locally (`pip install check-jsonschema`)
 
 ## Updating the specification
 
@@ -52,15 +57,32 @@ mdbook serve --open
 
 This will open the default web browser and point it at the local web server.
 
-## Building the specification
+## Validating your changes locally
 
-To build the book, using Terminal:
+Before opening a pull request, it's worth running the same checks CI will run. From the root of the repository:
+
+```
+pip install check-jsonschema
+check-jsonschema --schemafile metadata/schema/glyphnames.schema.json metadata/glyphnames.json
+check-jsonschema --schemafile metadata/schema/ranges.schema.json metadata/ranges.json
+check-jsonschema --schemafile metadata/schema/classes.schema.json metadata/classes.json
+python3 metadata/schema/check_consistency.py
+```
+
+And that the book itself builds without errors:
 
 ```
 cd mdbook
 mdbook build
 ```
 
-This creates a folder called **book**. Rename this folder to **latest** and replace the existing **latest** folder in the root of the repository with this folder.
+## Building and publishing the specification
 
-Now commit and push to the **gh-pages** branch.
+Publishing is automated. Every push and pull request against **gh-pages** triggers the **Validate and publish specification** GitHub Actions workflow (`.github/workflows/pages.yml`), which:
+
+1. Validates **glyphnames.json**, **classes.json** and **ranges.json** against their JSON Schemas, and runs the cross-file consistency checks.
+2. Builds the book with `mdbook build` to confirm the Markdown sources are well-formed.
+
+On a push to **gh-pages** (i.e. once a pull request is merged), a second job also runs, which builds the book again, assembles the site (the built book, plus **drafts**, **releases**, **gitbook**, **metadata**, **index.html** and **w3c.json**), and deploys it directly to GitHub Pages. There is no longer a manual "build, rename the folder, commit" step — merging is enough.
+
+This requires the repository's Pages source (Settings → Pages) to be set to "GitHub Actions" rather than "Deploy from a branch".

--- a/mdbook/book.toml
+++ b/mdbook/book.toml
@@ -1,6 +1,5 @@
 [book]
 authors = ["Daniel Spreadbury"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Standard Music Font Layout (SMuFL)"

--- a/metadata/schema/check_consistency.py
+++ b/metadata/schema/check_consistency.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Cross-file consistency checks for the SMuFL metadata files.
+
+These are checks that a JSON Schema alone can't express: relationships
+between glyphnames.json, ranges.json and classes.json. Run after schema
+validation has already passed.
+"""
+import json
+import sys
+from pathlib import Path
+
+METADATA_DIR = Path(__file__).resolve().parent.parent
+
+
+def codepoint_to_int(codepoint):
+    return int(codepoint[2:], 16)
+
+
+def main():
+    errors = []
+
+    glyphnames = json.loads((METADATA_DIR / "glyphnames.json").read_text())
+    ranges = json.loads((METADATA_DIR / "ranges.json").read_text())
+    classes = json.loads((METADATA_DIR / "classes.json").read_text())
+
+    # Every glyph referenced by a range must exist in glyphnames.json, and
+    # its codepoint must fall within that range's start/end.
+    glyphs_in_ranges = set()
+    for range_name, range_data in ranges.items():
+        range_start = codepoint_to_int(range_data["range_start"])
+        range_end = codepoint_to_int(range_data["range_end"])
+        if range_start > range_end:
+            errors.append(
+                f"ranges.json: '{range_name}' has range_start after range_end"
+            )
+        for glyph_name in range_data["glyphs"]:
+            glyphs_in_ranges.add(glyph_name)
+            glyph = glyphnames.get(glyph_name)
+            if glyph is None:
+                errors.append(
+                    f"ranges.json: '{range_name}' references unknown glyph '{glyph_name}'"
+                )
+                continue
+            codepoint = codepoint_to_int(glyph["codepoint"])
+            if not (range_start <= codepoint <= range_end):
+                errors.append(
+                    f"ranges.json: '{glyph_name}' codepoint {glyph['codepoint']} "
+                    f"is outside range '{range_name}' "
+                    f"({range_data['range_start']}-{range_data['range_end']})"
+                )
+
+    # Every glyph in glyphnames.json should belong to exactly one range.
+    for glyph_name in glyphnames:
+        if glyph_name not in glyphs_in_ranges:
+            errors.append(
+                f"glyphnames.json: '{glyph_name}' is not a member of any range in ranges.json"
+            )
+
+    # No two glyphs should share a codepoint.
+    codepoints_seen = {}
+    for glyph_name, glyph in glyphnames.items():
+        codepoint = glyph["codepoint"]
+        if codepoint in codepoints_seen:
+            errors.append(
+                f"glyphnames.json: codepoint {codepoint} is used by both "
+                f"'{codepoints_seen[codepoint]}' and '{glyph_name}'"
+            )
+        else:
+            codepoints_seen[codepoint] = glyph_name
+
+    # Every glyph referenced by a class must exist in glyphnames.json.
+    for class_name, glyph_list in classes.items():
+        for glyph_name in glyph_list:
+            if glyph_name not in glyphnames:
+                errors.append(
+                    f"classes.json: '{class_name}' references unknown glyph '{glyph_name}'"
+                )
+
+    if errors:
+        print(f"Found {len(errors)} consistency error(s):\n", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"ok -- {len(glyphnames)} glyphs, {len(ranges)} ranges, {len(classes)} classes consistent")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/metadata/schema/classes.schema.json
+++ b/metadata/schema/classes.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://w3c.github.io/smufl/metadata/schema/classes.schema.json",
+  "title": "SMuFL classes.json",
+  "description": "Maps each SMuFL glyph class name to the list of glyph names that are members of it.",
+  "type": "object",
+  "additionalProperties": {
+    "type": "array",
+    "items": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "minProperties": 1
+}

--- a/metadata/schema/glyphnames.schema.json
+++ b/metadata/schema/glyphnames.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://w3c.github.io/smufl/metadata/schema/glyphnames.schema.json",
+  "title": "SMuFL glyphnames.json",
+  "description": "Maps each canonical SMuFL glyph name to its codepoint, description, and (where applicable) alternate Unicode codepoint.",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "codepoint": {
+        "type": "string",
+        "pattern": "^U\\+[0-9A-F]{4,6}$"
+      },
+      "description": {
+        "type": "string",
+        "minLength": 1
+      },
+      "alternateCodepoint": {
+        "type": "string",
+        "pattern": "^U\\+[0-9A-F]{4,6}$"
+      }
+    },
+    "required": ["codepoint", "description"],
+    "additionalProperties": false
+  },
+  "minProperties": 1
+}

--- a/metadata/schema/ranges.schema.json
+++ b/metadata/schema/ranges.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://w3c.github.io/smufl/metadata/schema/ranges.schema.json",
+  "title": "SMuFL ranges.json",
+  "description": "Defines each SMuFL glyph range: its codepoint span, description, and member glyph names.",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "description": {
+        "type": "string",
+        "minLength": 1
+      },
+      "range_start": {
+        "type": "string",
+        "pattern": "^U\\+[0-9A-F]{4,6}$"
+      },
+      "range_end": {
+        "type": "string",
+        "pattern": "^U\\+[0-9A-F]{4,6}$"
+      },
+      "glyphs": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "required": ["description", "range_start", "range_end", "glyphs"],
+    "additionalProperties": false
+  },
+  "minProperties": 1
+}


### PR DESCRIPTION
## Summary

- Adds JSON Schemas for `glyphnames.json`, `ranges.json` and `classes.json`, plus a cross-file consistency check script (`metadata/schema/check_consistency.py`) that verifies glyph/range/class relationships that a schema alone can't express.
- Adds a GitHub Actions workflow (`.github/workflows/pages.yml`) that:
  - validates the metadata files and confirms the mdBook build succeeds on every push and pull request against `gh-pages`
  - on push to `gh-pages`, builds the book, assembles the full site (`latest/`, `drafts/`, `releases/`, `gitbook/`, `metadata/`, `index.html`, `w3c.json`) and deploys it via GitHub Pages — replacing the manual "build, rename `book/` to `latest/`, commit" step previously documented in `BUILDING.md`
- Removes the deprecated `multilingual` field from `mdbook/book.toml`, which current mdBook releases reject as an unknown key (required for the CI build to succeed at all).
- Updates `BUILDING.md` to document the new automated flow and local validation steps.

## Requires

For the `deploy` job to work, repository **Settings → Pages → Source** needs to be switched from "Deploy from a branch" to "GitHub Actions" before merging.

## Test plan

- [x] Validated all three JSON Schemas against the current `metadata/*.json` files locally — pass
- [x] Ran `check_consistency.py` against current metadata — pass (2932 glyphs, 131 ranges, 85 classes, no errors)
- [x] Built the book locally with mdBook v0.5.4 (the version pinned in the workflow) after the `book.toml` fix — succeeds
- [x] Manually replicated the `deploy` job's site-assembly step and confirmed the resulting directory structure matches what's currently published
- [x] Linted the workflow with `actionlint` — no issues
- [x] Confirm a real run of the `validate` job on this PR — passed: https://github.com/w3c-cg/smufl/actions/runs/31013581221/job/92331734421
- [ ] After merging, confirm the `deploy` job publishes correctly (requires the Pages source setting change above first)

Note: the first automated deploy will show a full-site diff in the built HTML even though no spec content changed, because current mdBook content-hashes asset filenames (`book.js` -> `book-<hash>.js`) unlike the mdBook version used for the last manual build. Expected, not a regression.

Generated with Claude Code

