### PR TITLE
Restore previous typography (font, line-height) lost in mdBook upgrade

### DIFF
--- a/mdbook/theme/css/general.css
+++ b/mdbook/theme/css/general.css
@@ -7,7 +7,8 @@
 }
 
 html {
-    font-family: "Open Sans", sans-serif;
+    /* Site customisation: was "Open Sans", sans-serif in mdBook's default. */
+    font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
     color: var(--fg);
     background-color: var(--bg);
     text-size-adjust: none;
@@ -105,9 +106,10 @@ html:not(.js) .page-wrapper,
     margin-inline-end: auto;
     max-width: var(--content-max-width);
 }
-.content p { line-height: 1.45em; }
-.content ol { line-height: 1.45em; }
-.content ul { line-height: 1.45em; }
+/* Site customisation: was 1.45em in mdBook's default. */
+.content p { line-height: 1.8em; }
+.content ol { line-height: 1.8em; }
+.content ul { line-height: 1.8em; }
 .content a { text-decoration: none; }
 .content a:hover { text-decoration: underline; }
 .content img, .content video { max-width: 100%; }
@@ -126,6 +128,8 @@ html:not(.js) .page-wrapper,
 table {
     margin: 0 auto;
     border-collapse: collapse;
+    /* Site customisation: not present in mdBook's default table rule. */
+    line-height: 1.8em;
 }
 table td {
     padding: 3px 20px;


### PR DESCRIPTION
## Summary

Restores the site's previous typography, lost when CI switched the book build to current mdBook (0.5.4) in #340/#341.

mdBook 0.5.4's own default theme uses `"Open Sans", sans-serif` and a `line-height` of `1.45em` for body content, both tighter than what the site used previously (visible in the archived 1.4 spec at https://www.w3.org/2021/03/smufl14/, and in this repo's history prior to the mdBook version bump).

## Changes

In `mdbook/theme/css/general.css`:
- `html` font-family: `"Open Sans", sans-serif` -> `"Helvetica Neue", "Helvetica", "Arial", sans-serif`
- `.content p`, `.content ol`, `.content ul` line-height: `1.45em` -> `1.8em`
- `table` line-height: not set in the default -> `1.8em` (matches the paragraph/list spacing)

Each change is marked with a comment noting it's a deviation from mdBook's default, so a future mdBook upgrade (which replaces this file wholesale, per the note already at the bottom of the file) doesn't silently drop them again.

## Test plan

- [x] Built locally with mdBook v0.5.4 and confirmed via computed styles: font-family resolves to Helvetica Neue, paragraph/table line-height computes to 28.8px (16px x 1.8em)
- [x] Visually compared rendered pages (glyph tables and prose pages) against the archived 1.4 spec — spacing and font now match
- [x] Confirmed the nav-arrow/sidebar fix from #341 is unaffected
- [ ] Confirm on the live site once merged
