### PR TITLE
Remove incorrect firstPublishedIn from tuplets-supplement range

### DIFF
--- a/data/ranges/tuplets-supplement.yaml
+++ b/data/ranges/tuplets-supplement.yaml
@@ -1,6 +1,5 @@
 name: tupletsSupplement
 description: Tuplets supplement
-firstPublishedIn: '1.4'
 implementationNotes: implementation_notes/tuplets.md
 codepointRangeStart: U+EF10
 codepointRangeEnd: U+EF17


### PR DESCRIPTION
## Summary

- \`data/ranges/tuplets-supplement.yaml\` had \`firstPublishedIn: '1.4'\`, but this range was newly constructed as part of the YAML migration and was never actually published in v1.4. That field marks a range as already-published (and therefore codepoint-immutable), which shouldn't apply here.
- Purely a documentation correction — this field isn't consumed by \`tools/generate.py\` or \`metadata/schema/check_immutability.py\`, so \`generate.py --check\` confirms nothing generated changes.

## Test plan

- [x] \`tools/generate.py --check\` passes (no generated output diff)
- [x] Range schema validation passes