### PR TITLE
Recommend a virtualenv in CONTRIBUTING.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Gemfile.lock
 
 __pycache__/
 *.pyc
+.venv/
 
 # Built by tools/generate_font.py - a build artifact, not committed (see
 # CONTRIBUTING.md "How this connects to Bravura").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,24 @@ only inserts an `{{#include}}` reference to it, it doesn't touch its content.
 
 ## Prerequisites
 
+Use a virtual environment rather than a bare `pip install` — on macOS with a Homebrew
+Python in particular, a bare `pip install` either refuses to run (Homebrew's Python
+blocks installing outside a venv) or silently installs into the wrong Python if you have
+more than one on your machine (`pip`/`python3` resolving to different interpreters is a
+common source of "ModuleNotFoundError" even though the install "succeeded"):
+
 ```
+cd smufl
+python3 -m venv .venv
+source .venv/bin/activate        # run this again in any new terminal session
 pip install pyyaml check-jsonschema fonttools ufoLib2
 ```
+
+`.venv/` is gitignored — safe to create inside your checkout. Run `deactivate` to leave
+the virtual environment; `source .venv/bin/activate` again next time you come back to it.
+
+Font-building work (see "How this connects to Bravura" below) needs a couple more
+packages in the same virtual environment: `pip install fontmake afdko`.
 
 [Install mdBook](https://rust-lang.github.io/mdBook/guide/installation.html) if you want
 to preview the built spec locally (`mdbook serve --open` from the `mdbook/` folder).


### PR DESCRIPTION
## Summary

- A bare `pip install` either gets blocked by Homebrew's externally-managed Python (PEP 668) or silently installs into the wrong interpreter when a machine has more than one Python. Recommends a `.venv` upfront in the Prerequisites section instead, explaining why.
- Adds `.venv/` to `.gitignore`.