### PR TITLE
Add GDEF to Bravura Text, add DSIG to both fonts

### DIFF
--- a/tools/font_build_common.py
+++ b/tools/font_build_common.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Small helpers shared by tools/generate_font.py and
+tools/generate_bravura_text.py that operate on the compiled OTF rather
+than the UFO source - things with no UFO-level representation at all.
+"""
+from fontTools.ttLib import newTable
+
+
+def add_dummy_dsig(ttfont):
+    """Adds an empty (zero-signature) DSIG table, in place. This is the
+    standard "dummy" DSIG some Windows/legacy consumers expect a font to
+    have at all - it carries no actual signature data (SMuFL fonts aren't
+    cryptographically signed), it's a completeness/compatibility marker,
+    same as what FontLab wrote into the previous shipped builds."""
+    dsig = newTable("DSIG")
+    dsig.ulVersion = 1
+    dsig.usNumSigs = 0
+    dsig.usFlag = 1
+    dsig.signatureRecords = []
+    ttfont["DSIG"] = dsig

--- a/tools/generate_bravura_text.py
+++ b/tools/generate_bravura_text.py
@@ -33,6 +33,11 @@ changed and new members are only ever added with higher codepoints than
 uses of the same base range (true under SMuFL's normal codepoint-immutable
 allocation model, just not mechanically enforced).
 
+Also classifies every ligature glyph (the newly-generated ones and
+Bravura's own native ones, which pass through unchanged) for GDEF, and
+adds a dummy DSIG table after compiling - see tools/generate_font.py and
+tools/font_build_common.py for why.
+
 Usage:
     python3 tools/generate_bravura_text.py [--output PATH] [--keep-tmp]
 """
@@ -46,6 +51,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import generate  # tools/generate.py
 import font_version  # tools/font_version.py
+import font_build_common  # tools/font_build_common.py
 
 import ufoLib2
 import yaml
@@ -205,6 +211,7 @@ def generate_ligatures(font, classes_by_glyph, merged_glyphnames, markers):
     )
 
     substitutions = []
+    new_ligature_names = []
     codepoint = LIGATURE_CODEPOINT_START
     for base_name in base_names:
         base_cp = generate.cp_int(merged_glyphnames[base_name]["codepoint"])
@@ -229,10 +236,11 @@ def generate_ligatures(font, classes_by_glyph, merged_glyphnames, markers):
             )
 
             substitutions.append(f"  sub {marker_ufo_name} {base_ufo_name} by {lig_name}; # {base_name} with {marker_name}")
+            new_ligature_names.append(lig_name)
             codepoint += 1
 
     print(f"Created {len(substitutions)} ligature glyphs (U+{LIGATURE_CODEPOINT_START:X}-U+{codepoint - 1:X})")
-    return substitutions
+    return substitutions, new_ligature_names
 
 
 def build_liga_feature(substitutions):
@@ -309,12 +317,21 @@ def build_otf(tmp_dir):
     base_family = font.info.familyName
 
     transform_glyphs(font, transforms, classes_by_glyph, index)
-    substitutions = generate_ligatures(font, classes_by_glyph, merged_glyphnames, markers)
+    substitutions, new_ligature_names = generate_ligatures(font, classes_by_glyph, merged_glyphnames, markers)
     liga_feature = build_liga_feature(substitutions)
     font.features.text = (font.features.text or "") + "\n\n" + liga_feature
 
     rename_font(font, base_family)
     odds_and_sods(font)
+
+    # GDEF ligature classification - not something FontLab's export carries
+    # (same reasoning as tools/generate_font.py), covering both the newly
+    # generated combining-staff-position ligatures and Bravura's own native
+    # ligatures (which pass through into Bravura Text unchanged).
+    native_ligature_names = {ufo_name for ufo_name, info in index.items() if info["category"] == "ligature"}
+    all_ligature_names = set(new_ligature_names) | native_ligature_names
+    font.lib["public.openTypeCategories"] = {n: "ligature" for n in all_ligature_names if n in font}
+    print(f"Classified {len(font.lib['public.openTypeCategories'])} ligature glyph(s) for GDEF")
 
     working_ufo = tmp_dir / "BravuraText.ufo"
     print(f"Saving working UFO to {working_ufo} ({len(font)} glyphs)")
@@ -322,6 +339,12 @@ def build_otf(tmp_dir):
 
     otf_path = tmp_dir / "BravuraText.otf"
     run(["fontmake", "-u", str(working_ufo), "-o", "otf", "--output-path", str(otf_path), "--no-subroutinize"])
+
+    ttfont = TTFont(otf_path)
+    font_build_common.add_dummy_dsig(ttfont)
+    ttfont.save(otf_path)
+    print("Added DSIG table")
+
     return otf_path
 
 

--- a/tools/generate_font.py
+++ b/tools/generate_font.py
@@ -11,6 +11,10 @@ injects public.openTypeCategories (ligature glyphs only - see
 tools/generate.py's build_font_glyph_index) into a throwaway copy of the UFO
 before compiling, so the committed Bravura.ufo never needs to carry it.
 
+Also adds a dummy (zero-signature) DSIG table after compiling - see
+tools/font_build_common.py - matching what previous FontLab-built releases
+carried.
+
 Usage:
     python3 tools/generate_font.py [--output PATH] [--no-hint] [--keep-tmp]
 """
@@ -28,6 +32,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import generate  # tools/generate.py
 import generate_font_metadata  # tools/generate_font_metadata.py
 import font_version  # tools/font_version.py
+import font_build_common  # tools/font_build_common.py
+
+from fontTools.ttLib import TTFont
 
 ROOT = Path(__file__).resolve().parent.parent
 UFO_DIR = ROOT / "font" / "Bravura.ufo"
@@ -100,11 +107,17 @@ def build_otf(tmp_dir, no_hint=False):
     ])
 
     if no_hint:
-        return unhinted_otf
+        final_otf = unhinted_otf
+    else:
+        final_otf = tmp_dir / "Bravura.otf"
+        run(["otfautohint", "-o", str(final_otf), str(unhinted_otf)])
 
-    hinted_otf = tmp_dir / "Bravura.otf"
-    run(["otfautohint", "-o", str(hinted_otf), str(unhinted_otf)])
-    return hinted_otf
+    ttfont = TTFont(final_otf)
+    font_build_common.add_dummy_dsig(ttfont)
+    ttfont.save(final_otf)
+    print("Added DSIG table")
+
+    return final_otf
 
 
 def main():


### PR DESCRIPTION
## Summary

Follow-up from comparing the freshly-built 1.4900 Bravura/Bravura Text against the last shipped 1.455/1.393 binaries (see PR discussion):

- **Bravura Text was missing GDEF entirely.** `generate_font.py` classifies Bravura's 201 native ligature glyphs for GDEF, but that step was never added to `generate_bravura_text.py`. Now classifies both its ~15,552 newly-generated combining-staff-position ligatures and Bravura's own 201 native ligatures that pass through unchanged (15,753 total, confirmed in the compiled font).
- **Both fonts now get a dummy DSIG table** (zero signatures — matches what FontLab's builds always included; this is a legacy Windows-compatibility marker, not real signing). Neither DSIG nor GDEF-from-ligature-classification has any UFO-level representation, so both are added as a post-compile step via the new `tools/font_build_common.py`, applied after `otfautohint` for Bravura and after `fontmake` for Bravura Text.

## Validation

- `tools/generate_font.py`: rebuilt, confirmed `DSIG` present (`ulVersion=1, usNumSigs=0`) and `GDEF` present (201 glyphs classified "ligature").
- `tools/generate_bravura_text.py`: rebuilt, confirmed `DSIG` present and `GDEF` present (15,753 glyphs classified "ligature").
- `tools/check_font_version.py` still passes without a version bump — correct, since this changes build tooling only, not font content.

## Test plan

- [x] `tools/generate.py --check`, `sync_ufo_glyphs.py --check`, `check_font_version.py` all pass locally
- [x] Both font builders compile cleanly end-to-end with the new tables verified present
- [ ] CI run on this PR