### PR TITLE
Let workflow_dispatch trigger a deploy, not just validate

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -100,7 +100,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: validate
-    if: github.event_name == 'push' && github.ref == 'refs/heads/gh-pages'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/gh-pages'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Three consecutive pushes to \`gh-pages\` today had their \`Deploy to GitHub Pages\` step time out (\`deployment_queued\` for the whole timeout window, then aborted) - a GitHub Pages backend issue on this repo, not something wrong in our workflow (validate/build/upload-artifact all succeeded each time; GitHub's own status page shows everything operational, so this looks localized).

While diagnosing, I tried manually re-triggering the workflow via \`workflow_dispatch\` to retry the deploy - it silently only ran the \`validate\` job and reported overall success, because the \`deploy\` job's \`if\` condition gated on \`github.event_name == 'push'\` only. Broadens it to also allow \`workflow_dispatch\`, so a maintainer can force a redeploy attempt without needing a new commit - directly useful for recovering from exactly this kind of stuck deployment.

## Test plan

- [x] Confirmed the previous 3 failures were all genuine GitHub Pages backend timeouts, not workflow bugs (validate always passed; deploy always got stuck in \`deployment_queued\`)
- [x] Confirmed a `workflow_dispatch` run currently skips the deploy job entirely due to the old condition
- [ ] After merge, this fix's own push should get a fresh, real deploy through