### PR TITLE
Rename release metadata output to Bravura.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,7 +341,7 @@ re-exporting the UFO can never accidentally change the shipped version.
 
 `python3 tools/generate_font.py --generate-release [--output-dir PATH] [--fixed-issues REF,...]`
 assembles the structure found in the Bravura repository's `redist/` folder: OTF and WOFF/WOFF2
-for both fonts, `bravura_metadata.json`, and an updated `FONTLOG.txt` (SVG font export is
+for both fonts, `Bravura.json`, and an updated `FONTLOG.txt` (SVG font export is
 deliberately not included — that format is deprecated). Point `--output-dir` at a checkout of
 the Bravura repo's `redist/` folder to update it directly; `--fixed-issues` (comma-separated,
 e.g. `steinbergmedia/bravura#101,w3c-cg/smufl#42`) fetches each issue's title via `gh issue

--- a/tools/generate_release.py
+++ b/tools/generate_release.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Assembles a full Bravura release - the structure found in the Bravura
 repository's redist/ folder: OTF and WOFF/WOFF2 versions of both Bravura
-and Bravura Text, bravura_metadata.json, and an updated FONTLOG.txt.
+and Bravura Text, Bravura.json, and an updated FONTLOG.txt.
 
 Invoked via `python3 tools/generate_font.py --generate-release`, not run
 directly (it needs the working UFO/build machinery from generate_font.py
@@ -129,9 +129,14 @@ def build_release(output_dir, fixed_issues=None, author="Daniel Spreadbury", kee
         text_otf = generate_bravura_text.build_otf(text_tmp)
         build_format_variants(text_otf, output_dir, "BravuraText")
 
-        print("Building bravura_metadata.json...")
+        print("Building Bravura.json...")
+        # Named to match the font, per the spec's own convention
+        # (font-metadata-locations.md: ".../SMuFL/Fonts/<fontname>/<fontname>.json")
+        # - the redist zip previously shipped this as "bravura_metadata.json",
+        # which never matched what the spec (or Dorico's own bundled copy)
+        # actually expects. See steinbergmedia/bravura#85.
         metadata = generate_font_metadata.build_metadata(bravura_otf)
-        metadata_path = output_dir / "bravura_metadata.json"
+        metadata_path = output_dir / "Bravura.json"
         import json
         metadata_path.write_text(json.dumps(metadata, indent=4, sort_keys=True))
         print(f"  wrote {metadata_path}")
@@ -151,7 +156,7 @@ def build_release(output_dir, fixed_issues=None, author="Daniel Spreadbury", kee
 def add_release_args(parser):
     parser.add_argument("--generate-release", action="store_true",
                          help="build a full release (Bravura + Bravura Text, all formats, "
-                              "bravura_metadata.json, FONTLOG.txt) instead of a single font")
+                              "Bravura.json, FONTLOG.txt) instead of a single font")
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR,
                          help="release output directory (default: font/release/). Point this "
                               "at a checkout of the Bravura repo's redist/ folder to update it directly.")


### PR DESCRIPTION
## Summary

\`tools/generate_release.py\` named its metadata output \`bravura_metadata.json\`, copied from the historical redist convention without checking it against the spec. Per [font-metadata-locations.md](https://w3c-cg.github.io/smufl/latest/specification/font-metadata-locations.html), the file should be named after the font itself (\`Bravura.json\`) - Dorico's bundled copy already follows this; the standalone GitHub redist zip has just never matched it. See [steinbergmedia/bravura#85](https://github.com/steinbergmedia/bravura/issues/85).

Matches the rename already made directly in the Bravura repo's \`redist/\` folder.

Note: \`scripts/fontlab/*.py\` and \`scripts/glyphsapp/*.py\` also reference \`bravura_metadata.json\` - left untouched here, that's a separate concern (font-editor helper scripts, not the generation pipeline) if it needs addressing too.

## Test plan

- [x] \`tools/generate_release.py\` rebuilt, confirmed output is \`Bravura.json\`
- [x] \`tools/generate.py --check\`, \`sync_ufo_glyphs.py --check\`, \`check_font_version.py\` all pass locally (no font-content change, tooling only)