### PR TITLE
Increase deploy-pages timeout from 10 to 30 minutes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -169,3 +169,13 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          # Default is 10 minutes (600000ms). GitHub Pages deployments for
+          # this repo have been taking noticeably longer than that lately
+          # (observed: status still "deployment_in_progress"/"queued" well
+          # past 10 minutes, with the underlying publish completing anyway
+          # a few minutes after this action gives up and reports failure -
+          # confirmed by checking the live site content after a "failed"
+          # run). Longer timeout lets the status check actually observe
+          # success instead of a false-negative failure report.
+          timeout: 1800000


### PR DESCRIPTION
## Summary

The last 5 consecutive push-triggered deploys (#346-#350) were reported as \`failure\` by \`actions/deploy-pages@v4\`, but checking the live site content after each one shows the underlying publish actually succeeded - the deployment status just hadn't transitioned to \`success\` within the action's default 10-minute polling window (\`deployment_in_progress\`/\`deployment_queued\` right up to the timeout).

This isn't something wrong in our workflow logic (validate/build/upload-artifact all succeed every time) - it looks like GitHub Pages deployments for this repo have been taking noticeably longer than usual recently. Bumping \`timeout\` to 30 minutes gives the status check enough patience to observe the real outcome instead of reporting a false-negative failure.

## Test plan

- [x] Confirmed via \`last-modified\` header + rendered page content that "failed" deploys actually published (e.g. #347's Bravura Text section is live despite that run showing failure)
- [ ] This PR's own merge should be a real-world test of the longer timeout