### PR TITLE
Fix version scheme: 3-digit fraction, not 4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,11 +317,19 @@ Two more tools close the rest of the loop, and both run in CI on every PR:
 ### Font version numbering
 
 `data/font-version.yaml` is the single source of truth for both fonts' version number (they're
-always rebuilt together, so they share one). `stem` (e.g. `"1.49"`) tracks the SMuFL spec
-version being worked towards — bump it to `"1.50"` (resetting `build` to `0`) only once SMuFL
-1.5 is actually ready for release, as a deliberate decision. `build` increments on every
-*material* change to the font — not every rebuild; a rebuild with no real design change keeps
-the same number.
+always rebuilt together, so they share one). The full number is `stem` + `build`, zero-padded
+so the fraction is always exactly 3 digits (e.g. stem `"1.4"` + build `80` → `"1.480"`) — no
+more, no fewer: `head.fontRevision` is a Fixed 16.16 *number*, not a string, so a 4th digit
+is never actually recoverable once written (every tool that reads it back rounds/truncates
+to the ecosystem's standard 3 digits) — see [steinbergmedia/bravura#102](https://github.com/steinbergmedia/bravura/issues/102),
+which caught an earlier version of this scheme getting that wrong.
+
+`stem` tracks the SMuFL spec version being worked towards — bump it (e.g. `"1.4"` → `"1.5"`)
+only once the next SMuFL version is actually ready for release, as a deliberate decision, at
+the same time resetting `build` to a fresh starting point comfortably above the last *real*
+shipped version under the old numbering (not necessarily `0` — see the comments in
+`data/font-version.yaml`). `build` increments on every *material* change to the font — not
+every rebuild; a rebuild with no real design change keeps the same number.
 
 `tools/check_font_version.py` enforces this in CI: it hashes the actual build inputs
 (`font/Bravura.ufo` — skipping empty placeholder glyphs, since adding one isn't a material

--- a/data/font-version.yaml
+++ b/data/font-version.yaml
@@ -6,24 +6,37 @@
 # designer re-exporting the UFO can never accidentally change the shipped
 # version number.
 #
-# stem: the part that tracks the SMuFL spec version, e.g. "1.49" for
+# The full version number is stem + build, zero-padded so the fractional
+# part is exactly 3 digits total, e.g. stem "1.4" + build 80 => "1.480".
+# Three digits, not more, is deliberate: head.fontRevision is a Fixed
+# 16.16 *number*, not a string - it genuinely cannot distinguish "1.480"
+# from "1.4800" (see steinbergmedia/bravura#102, which caught an earlier
+# version of this scheme using a 4-digit fraction; every tool that reads
+# fontRevision back rounds/truncates to the ecosystem's standard 3 digits,
+# so a 4th digit is never actually recoverable - not just untidy, actively
+# broken).
+#
+# stem: the part that tracks the SMuFL spec version, e.g. "1.4" for
 # "working towards 1.5, following the 1.4 release". This is a deliberate,
-# infrequent decision - bump it to "1.50" only once SMuFL 1.5 is actually
-# ready for release, at the same time resetting build to 0.
+# infrequent decision - bump it to "1.5" only once SMuFL 1.5 is actually
+# ready for release, at the same time resetting build to a fresh starting
+# point (see below - NOT 0).
 #
-# build: increments on every MATERIAL change to the font (not every
-# rebuild - a rebuild with no real design change keeps the same number).
-# tools/check_font_version.py enforces this: it hashes the actual build
-# inputs (font/Bravura.ufo minus fontinfo.plist, plus the metadata/data
-# files that feed generate_font.py and generate_bravura_text.py) and fails
-# CI if that hash has changed but build wasn't incremented and inputsHash
-# wasn't refreshed to match. Two digits (00-99) gives 100 revisions of
-# headroom before stem needs to change anyway.
+# build: two digits (00-99), incrementing on every MATERIAL change to the
+# font (not every rebuild - a rebuild with no real design change keeps the
+# same number). tools/check_font_version.py enforces this: it hashes the
+# actual build inputs (font/Bravura.ufo minus fontinfo.plist, plus the
+# metadata/data files that feed generate_font.py and
+# generate_bravura_text.py) and fails CI if that hash has changed but
+# build wasn't incremented and inputsHash wasn't refreshed to match.
 #
-# The full version number is stem + build zero-padded to 2 digits, e.g.
-# stem "1.49" + build 0 => "1.4900".
-stem: "1.49"
-build: 0
+# Starting build at 80 (not 0) when a new stem begins is also deliberate:
+# it keeps the very first version under a new stem numerically ABOVE the
+# last real release under the old numbering (1.456), so nothing mistakes
+# the new scheme's first release for a downgrade, while still leaving 20
+# revisions (80-99) of headroom before the next stem bump is needed.
+stem: "1.4"
+build: 80
 
 # sha256 of the build inputs as of this version number - see
 # tools/check_font_version.py. Refresh with:

--- a/data/schema/font-version.schema.json
+++ b/data/schema/font-version.schema.json
@@ -3,7 +3,7 @@
   "title": "Bravura / Bravura Text build version",
   "type": "object",
   "properties": {
-    "stem": { "type": "string", "pattern": "^[0-9]+\\.[0-9]{2}$" },
+    "stem": { "type": "string", "pattern": "^[0-9]+\\.[0-9]$" },
     "build": { "type": "integer", "minimum": 0, "maximum": 99 },
     "inputsHash": { "type": "string", "pattern": "^([0-9a-f]{64})?$" }
   },

--- a/tools/font_version.py
+++ b/tools/font_version.py
@@ -56,10 +56,14 @@ def save(data):
 
 
 def format_version(version_data=None):
-    """Returns (versionMajor, versionMinor, version_str) e.g. (1, 4900, "1.4900").
-    version_str is a string, not a float, deliberately - the trailing
-    zeros in e.g. "1.4900" are significant (they're the build number) and
-    a float would silently drop them (float("1.4900") == 1.49)."""
+    """Returns (versionMajor, versionMinor, version_str) e.g. (1, 480, "1.480").
+    version_str is a string, not a float, deliberately - a float would
+    silently drop a trailing zero for some build values (float("1.480")
+    == 1.48). That's harmless for THIS scheme's 3-digit fraction (1.48
+    and 1.480 are the same number, and no other valid build value
+    collides with it), but keeping this as a string avoids relying on
+    that being true - see data/font-version.yaml and
+    steinbergmedia/bravura#102 for why the fraction is 3 digits, not 4."""
     data = version_data or load()
     major_str, minor_stem = data["stem"].split(".")
     minor_str = f"{minor_stem}{data['build']:02d}"

--- a/tools/generate_font_metadata.py
+++ b/tools/generate_font_metadata.py
@@ -52,9 +52,9 @@ def font_info():
     fontinfo = plistlib.loads((UFO_DIR / "fontinfo.plist").read_bytes())
     staff_space = fontinfo["unitsPerEm"] / 4
     # fontVersion is a JSON number (matching the historical smufl-admin
-    # export), which can't distinguish "1.4900" from "1.49" - the build
-    # number's trailing zeros are only meaningful in the font's own
-    # name-table "Version" string and in versionMajor/versionMinor.
+    # export) - fine for this scheme's 3-digit fraction (e.g. 1.480 == 1.48
+    # as a float, and no other valid build value collides with that), see
+    # tools/font_version.py.
     _, _, version_str = font_version.format_version()
     return staff_space, float(version_str)
 


### PR DESCRIPTION
## Summary

\`head.fontRevision\` is a Fixed 16.16 *number*, not a string - it genuinely cannot distinguish \`1.480\` from \`1.4800\`. The previous 4-digit scheme's trailing "build" digit was never actually recoverable once written to the binary; every tool that reads \`fontRevision\` back rounds/truncates to the ecosystem's standard 3 digits (confirmed: our own 1.4900 build's raw fontRevision reports as 1.490 via third-party tooling). See [steinbergmedia/bravura#102](https://github.com/steinbergmedia/bravura/issues/102).

New scheme: \`stem\` is one digit (e.g. \`"1.4"\`), \`build\` is two digits (00-99), giving exactly a 3-digit fraction - \`stem "1.4" + build 80 => "1.480"\`. Starting \`build\` at 80 rather than 0 for this stem keeps the first release under the corrected scheme numerically above the last real release under the old numbering (1.456), so nothing mistakes it for a downgrade, while still leaving 20 revisions of headroom before the next stem bump.

## Test plan

- [x] Rebuilt Bravura.otf, confirmed \`fontRevision\` rounds cleanly to 1.48, name-table Version string reads "Version 1.480", Bravura.json's \`fontVersion\` is 1.48 - all consistent, no truncation ambiguity
- [x] \`tools/generate.py --check\`, \`sync_ufo_glyphs.py --check\`, \`check_font_version.py\`, schema validation all pass